### PR TITLE
strands_datacentre

### DIFF
--- a/strands_datacentre/CMakeLists.txt
+++ b/strands_datacentre/CMakeLists.txt
@@ -4,7 +4,7 @@ project(strands_datacentre)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED COMPONENTS roscpp rospy std_msgs std_srvs)
+find_package(catkin REQUIRED COMPONENTS message_generation roscpp rospy std_msgs std_srvs)
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
@@ -27,17 +27,17 @@ find_package(catkin REQUIRED COMPONENTS roscpp rospy std_msgs std_srvs)
 # )
 
 ## Generate services in the 'srv' folder
-# add_service_files(
-#   FILES
-#   Service1.srv
-#   Service2.srv
-# )
+add_service_files(
+  FILES
+  GetParam.srv
+  SetParam.srv
+)
 
 ## Generate added messages and services with any dependencies listed here
-# generate_messages(
-#   DEPENDENCIES
-#   std_msgs
-# )
+generate_messages(
+  DEPENDENCIES
+  std_msgs
+)
 
 ###################################
 ## catkin specific configuration ##

--- a/strands_datacentre/CMakeLists.txt
+++ b/strands_datacentre/CMakeLists.txt
@@ -1,0 +1,132 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(strands_datacentre)
+
+## Find catkin macros and libraries
+## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
+## is used, also find other catkin packages
+find_package(catkin REQUIRED COMPONENTS roscpp rospy std_msgs std_srvs)
+
+## System dependencies are found with CMake's conventions
+# find_package(Boost REQUIRED COMPONENTS system)
+
+
+## Uncomment this if the package has a setup.py. This macro ensures
+## modules and global scripts declared therein get installed
+## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
+# catkin_python_setup()
+
+#######################################
+## Declare ROS messages and services ##
+#######################################
+
+## Generate messages in the 'msg' folder
+# add_message_files(
+#   FILES
+#   Message1.msg
+#   Message2.msg
+# )
+
+## Generate services in the 'srv' folder
+# add_service_files(
+#   FILES
+#   Service1.srv
+#   Service2.srv
+# )
+
+## Generate added messages and services with any dependencies listed here
+# generate_messages(
+#   DEPENDENCIES
+#   std_msgs
+# )
+
+###################################
+## catkin specific configuration ##
+###################################
+## The catkin_package macro generates cmake config files for your package
+## Declare things to be passed to dependent projects
+## INCLUDE_DIRS: uncomment this if you package contains header files
+## LIBRARIES: libraries you create in this project that dependent projects also need
+## CATKIN_DEPENDS: catkin_packages dependent projects also need
+## DEPENDS: system dependencies of this project that dependent projects also need
+catkin_package(
+#  INCLUDE_DIRS include
+#  LIBRARIES strands_datacentre
+#  CATKIN_DEPENDS roscpp rospy std_msgs std_srvs
+#  DEPENDS system_lib
+)
+
+###########
+## Build ##
+###########
+
+## Specify additional locations of header files
+## Your package locations should be listed before other locations
+# include_directories(include)
+include_directories(
+  ${catkin_INCLUDE_DIRS}
+)
+
+## Declare a cpp library
+# add_library(strands_datacentre
+#   src/${PROJECT_NAME}/strands_datacentre.cpp
+# )
+
+## Declare a cpp executable
+# add_executable(strands_datacentre_node src/strands_datacentre_node.cpp)
+
+## Add cmake target dependencies of the executable/library
+## as an example, message headers may need to be generated before nodes
+# add_dependencies(strands_datacentre_node strands_datacentre_generate_messages_cpp)
+
+## Specify libraries to link a library or executable target against
+# target_link_libraries(strands_datacentre_node
+#   ${catkin_LIBRARIES}
+# )
+
+#############
+## Install ##
+#############
+
+# all install targets should use catkin DESTINATION variables
+# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
+
+## Mark executable scripts (Python etc.) for installation
+## in contrast to setup.py, you can choose the destination
+# install(PROGRAMS
+#   scripts/my_python_script
+#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+# )
+
+## Mark executables and/or libraries for installation
+# install(TARGETS strands_datacentre strands_datacentre_node
+#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+# )
+
+## Mark cpp header files for installation
+# install(DIRECTORY include/${PROJECT_NAME}/
+#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+#   FILES_MATCHING PATTERN "*.h"
+#   PATTERN ".svn" EXCLUDE
+# )
+
+## Mark other files for installation (e.g. launch and bag files, etc.)
+# install(FILES
+#   # myfile1
+#   # myfile2
+#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+# )
+
+#############
+## Testing ##
+#############
+
+## Add gtest based cpp test target and link libraries
+# catkin_add_gtest(${PROJECT_NAME}-test test/test_strands_datacentre.cpp)
+# if(TARGET ${PROJECT_NAME}-test)
+#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
+# endif()
+
+## Add folders to be run by python nosetests
+# catkin_add_nosetests(test)

--- a/strands_datacentre/defaults/README.md
+++ b/strands_datacentre/defaults/README.md
@@ -1,0 +1,1 @@
+Any YAML files in this directory will be read to provide default parameters.

--- a/strands_datacentre/launch/mongo.launch
+++ b/strands_datacentre/launch/mongo.launch
@@ -1,0 +1,6 @@
+<launch>
+  <param name="datacentre_port" value="62345" />
+  <node name="mongo_server" pkg="strands_datacentre" type="mongodb_server.py" output="screen">
+	<param name="database_path" value="/tmp/db"/>
+  </node>
+</launch>

--- a/strands_datacentre/package.xml
+++ b/strands_datacentre/package.xml
@@ -1,44 +1,14 @@
 <?xml version="1.0"?>
 <package>
   <name>strands_datacentre</name>
-  <version>0.0.0</version>
-  <description>The strands_datacentre package</description>
+  <version>0.0.1</version>
+  <description>A MongoDB based central store for strands data, eg. configurations, logged states, etc</description>
 
-  <!-- One maintainer tag required, multiple allowed, one person per tag --> 
-  <!-- Example:  -->
-  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
-  <maintainer email="chris@todo.todo">chris</maintainer>
+  <maintainer email="cburbridge@gmail.com">chris burbridge</maintainer>
+  <author email="cburbridge@gmail.com">chris burbridge</author>
 
+  <license>GPL</license>
 
-  <!-- One license tag required, multiple allowed, one license per tag -->
-  <!-- Commonly used license strings: -->
-  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
-  <license>TODO</license>
-
-
-  <!-- Url tags are optional, but mutiple are allowed, one per tag -->
-  <!-- Optional attribute type can be: website, bugtracker, or repository -->
-  <!-- Example: -->
-  <!-- <url type="website">http://ros.org/wiki/strands_datacentre</url> -->
-
-
-  <!-- Author tags are optional, mutiple are allowed, one per tag -->
-  <!-- Authors do not have to be maintianers, but could be -->
-  <!-- Example: -->
-  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
-
-
-  <!-- The *_depend tags are used to specify dependencies -->
-  <!-- Dependencies can be catkin packages or system dependencies -->
-  <!-- Examples: -->
-  <!-- Use build_depend for packages you need at compile time: -->
-  <!--   <build_depend>message_generation</build_depend> -->
-  <!-- Use buildtool_depend for build tool packages: -->
-  <!--   <buildtool_depend>catkin</buildtool_depend> -->
-  <!-- Use run_depend for packages you need at runtime: -->
-  <!--   <run_depend>message_runtime</run_depend> -->
-  <!-- Use test_depend for packages you need only for testing: -->
-  <!--   <test_depend>gtest</test_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>rospy</build_depend>
@@ -50,12 +20,8 @@
   <run_depend>std_srvs</run_depend>
 
 
-  <!-- The export tag contains other, unspecified, tags -->
-  <export>
-    <!-- You can specify that this package is a metapackage here: -->
-    <!-- <metapackage/> -->
 
-    <!-- Other tools can request additional information be placed here -->
+  <export>
 
   </export>
 </package>

--- a/strands_datacentre/package.xml
+++ b/strands_datacentre/package.xml
@@ -14,6 +14,7 @@
   <build_depend>rospy</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>std_srvs</build_depend>
+  <build_depend>message_generation</build_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>rospy</run_depend>
   <run_depend>std_msgs</run_depend>

--- a/strands_datacentre/package.xml
+++ b/strands_datacentre/package.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0"?>
+<package>
+  <name>strands_datacentre</name>
+  <version>0.0.0</version>
+  <description>The strands_datacentre package</description>
+
+  <!-- One maintainer tag required, multiple allowed, one person per tag --> 
+  <!-- Example:  -->
+  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
+  <maintainer email="chris@todo.todo">chris</maintainer>
+
+
+  <!-- One license tag required, multiple allowed, one license per tag -->
+  <!-- Commonly used license strings: -->
+  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
+  <license>TODO</license>
+
+
+  <!-- Url tags are optional, but mutiple are allowed, one per tag -->
+  <!-- Optional attribute type can be: website, bugtracker, or repository -->
+  <!-- Example: -->
+  <!-- <url type="website">http://ros.org/wiki/strands_datacentre</url> -->
+
+
+  <!-- Author tags are optional, mutiple are allowed, one per tag -->
+  <!-- Authors do not have to be maintianers, but could be -->
+  <!-- Example: -->
+  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
+
+
+  <!-- The *_depend tags are used to specify dependencies -->
+  <!-- Dependencies can be catkin packages or system dependencies -->
+  <!-- Examples: -->
+  <!-- Use build_depend for packages you need at compile time: -->
+  <!--   <build_depend>message_generation</build_depend> -->
+  <!-- Use buildtool_depend for build tool packages: -->
+  <!--   <buildtool_depend>catkin</buildtool_depend> -->
+  <!-- Use run_depend for packages you need at runtime: -->
+  <!--   <run_depend>message_runtime</run_depend> -->
+  <!-- Use test_depend for packages you need only for testing: -->
+  <!--   <test_depend>gtest</test_depend> -->
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>rospy</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>std_srvs</build_depend>
+  <run_depend>roscpp</run_depend>
+  <run_depend>rospy</run_depend>
+  <run_depend>std_msgs</run_depend>
+  <run_depend>std_srvs</run_depend>
+
+
+  <!-- The export tag contains other, unspecified, tags -->
+  <export>
+    <!-- You can specify that this package is a metapackage here: -->
+    <!-- <metapackage/> -->
+
+    <!-- Other tools can request additional information be placed here -->
+
+  </export>
+</package>

--- a/strands_datacentre/src/config_manager.py
+++ b/strands_datacentre/src/config_manager.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python
+
+import roslib; roslib.load_manifest('strands_datacentre')
+import rospy
+import sys
+import os
+import collections
+import json
+
+from strands_datacentre.srv import *
+from std_srvs.srv import *
+import rosparam
+
+try:
+    import pymongo
+except:
+    print("ERROR!!!")
+    print("Can't import pymongo, this is needed by strands_datacentre.")
+    print("Make sure it is installed (sudo apt-get install python-pymongo)")
+    sys.exit(1)
+
+
+class ConfigManager(object):
+    def __init__(self):
+        rospy.init_node("config_manager")
+        rospy.on_shutdown(self._on_node_shutdown)
+        
+        # Check that mongo is live, create connection
+        try:
+            rospy.wait_for_service("/datacentre/wait_ready",10)
+        except rospy.exceptions.ROSException, e:
+            rospy.logerr("Can't connect to MongoDB server. Make sure strands_datacentre/mongodb_server.py node is started.")
+            sys.exit(1)
+        wait = rospy.ServiceProxy('/datacentre/wait_ready', Empty)
+        wait()
+        self._mongo_client = pymongo.MongoClient(rospy.get_param("datacentre_host","localhost"),
+                                                 int(rospy.get_param("datacentre_port")))
+
+        # Load the default settings from the defaults/ folder
+        path = os.path.join(roslib.packages.get_pkg_dir('strands_datacentre'),"defaults")
+        files = os.listdir(path)
+        defaults=[]  # a list of 3-tuples, (param, val, originating_filename)
+        def flatten(d, c="", f_name="" ):
+            l=[]
+            for k, v in d.iteritems():
+                if isinstance(v, collections.Mapping):
+                    l.extend(flatten(v,c+"/"+k, f_name))
+                else:
+                    l.append((c+"/"+k, v, f_name))
+            return l
+                             
+        for f in files:
+            if not f.endswith(".yaml"):
+                continue
+            params = rosparam.load_file(os.path.join(path,f))
+            rospy.loginfo("Found default parameter file %s" % f)
+            for p, n in params:
+                defaults.extend(flatten(p,c="",f_name=f))
+
+        # Copy the defaults into the DB if not there already
+        defaults_collection = self._mongo_client.config.defaults
+        for param,val,filename in defaults:
+            existing = defaults_collection.find_one({"path":param})
+            if existing is None:
+                rospy.loginfo("New default parameter for %s"%param)
+                defaults_collection.insert({"path":param,
+                                            "value":val,
+                                            "from_file":filename})
+            elif existing["from_file"]!=filename:
+                rospy.logerr("Two defaults parameter files have the same key:\n%s and %s, key %s"%
+                             (existing["from_file"],filename,param))
+                # Delete the entry so that it can be fixed...
+                defaults_collection.remove(existing)
+                rospy.signal_shutdown("Default parameter set error")
+            elif existing["value"]!=val:
+                rospy.loginfo("Updating stored default for %s"%param)
+                defaults_collection.update(existing,{"$set":{"value":val}})
+        
+                
+        # Load the settings onto the ros parameter server
+        defaults_collection = self._mongo_client.config.defaults
+        local_collection = self._mongo_client.config.local
+        for param in defaults_collection.find():
+            name=param["path"]
+            val=param["value"]
+            if local_collection.find_one({"path":name}) is None:
+                rospy.set_param(name,val)
+        for param in local_collection.find():
+            name=param["path"]
+            val=param["value"]
+            rospy.set_param(name,val)
+
+        
+        # Advertise ros services for parameter setting / getting
+        self._getparam_srv = rospy.Service("/config_manager/get_param",
+                                           GetParam,
+                                           self._getparam_srv_cb)
+        self._setparam_srv = rospy.Service("/config_manager/set_param",
+                                           SetParam,
+                                           self._setparam_srv_cb)
+
+        
+        self._list_params()
+        
+        # Start the main loop
+        rospy.spin()
+
+    """
+    debug function, prints out all parameters known
+    """
+    def _list_params(self):
+        print "#"*10
+        print "Defaults:"
+        print
+        for param in self._mongo_client.config.defaults.find():
+            name=param["path"]
+            val=param["value"]
+            filename=param["from_file"]
+            print name, " "*(30-len(name)),val," "*(30-len(str(val))),filename
+        print
+        
+        
+    def _on_node_shutdown(self):
+        self._mongo_client.disconnect()
+
+    # Could just use the ros parameter server to get the params
+    # but one day might not back onto the parameter server...
+    def _getparam_srv_cb(self,req):
+        response = GetParamResponse()
+        config_db = self._mongo_client.config
+        value = config_db.local.find_one({"path":req.param_name})
+        if value is None:
+            value = config_db.defaults.find_one({"path":req.param_name})
+            if value is None:
+                response.success=False
+                return response
+        response.success=True
+        response.param_value=str(value["value"])
+        return response
+
+    """
+    Set the local site-specific parameter.
+    """
+    def _setparam_srv_cb(self,req):
+        print ("parse json")
+        new = json.loads(req.param)
+        if not (new.has_key("path") and new.has_key("value")):
+            rospy.logerr("Trying to set parameter but not giving full spec")
+            return SetParamResponse(False)
+        config_db_local = self._mongo_client.config.local
+        value = config_db_local.find_one({"path":new["path"]})
+        if value is None:
+            # insert it
+            config_db_local.insert(new)
+        else:
+            # update it
+            config_db_local.update(value,{"$set":new})
+            pass
+        return SetParamResponse(True)
+            
+
+if __name__ == '__main__':
+    server = ConfigManager()
+

--- a/strands_datacentre/src/mongodb_server.py
+++ b/strands_datacentre/src/mongodb_server.py
@@ -29,7 +29,9 @@ class MongoServer(object):
 
         # What server does mongodb reside
         self._mongo_host = rospy.get_param("datacentre_host", "localhost")
+        rospy.set_param("datacentre_host",self._mongo_host)
         self._mongo_port = rospy.get_param("datacentre_port", 27017)
+        rospy.set_param("datacentre_port",self._mongo_port)
         rospy.loginfo("Mongo server address: "+self._mongo_host+":"+str(self._mongo_port))
     
 
@@ -87,7 +89,7 @@ class MongoServer(object):
                 else:
                     rospy.loginfo(stdout.strip())
 
-                if stdout.find("waiting for connections on port"):
+                if stdout.find("waiting for connections on port") !=-1:
                     self._ready=True
 
         if not rospy.is_shutdown():

--- a/strands_datacentre/src/mongodb_server.py
+++ b/strands_datacentre/src/mongodb_server.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python
+
+import roslib; roslib.load_manifest('strands_datacentre')
+import rospy
+import subprocess
+import sys
+import os
+import re
+import signal
+import errno
+from std_srvs.srv import *
+
+try:
+    import pymongo
+except:
+    print("ERROR!!!")
+    print("Can't import pymongo, this is needed by strands_datacentre.")
+    print("Make sure it is installed (sudo apt-get install python-pymongo)")
+    sys.exit(1)
+
+
+class MongoServer(object):
+    def __init__(self):
+        rospy.init_node("mongodb_server")#, disable_signals=True)
+        rospy.on_shutdown(self._on_node_shutdown)
+
+        # Get the database path
+        self._db_path = rospy.get_param("~database_path", "/opt/strands/strands_datacentre")
+
+        # What server does mongodb reside
+        self._mongo_host = rospy.get_param("datacentre_host", "localhost")
+        self._mongo_port = rospy.get_param("datacentre_port", 27017)
+        rospy.loginfo("Mongo server address: "+self._mongo_host+":"+str(self._mongo_port))
+    
+
+        # Check that mongodb is installed
+        try:
+            mongov = subprocess.check_output(["mongod","--version"])
+            match = re.search("db version v(\d+\.\d+\.\d+)",mongov)
+            self._mongo_version=match.group(1)
+        except subprocess.CalledProcessError:
+            rospy.logerr("Can't find MongoDB executable. Is it installed?\nInstall it with  \"sudo apt-get install mongodb\"")
+            sys.exit(1)
+        rospy.loginfo("Foung MongoDB version " + self._mongo_version)
+
+        # Check that the provided db path exists.
+        if not os.path.exists(self._db_path):
+            rospy.logerr("Can't find supplied database. If this is a new DB, create it as an empty directory.")
+            sys.exit(1)
+
+        # Advertise ros services for db interaction
+        self._shutdown_srv = rospy.Service("/datacentre/shutdown", Empty, self._shutdown_srv_cb)
+        self._wait_ready_srv = rospy.Service("/datacentre/wait_ready",Empty,self._wait_ready_srv_cb)
+
+        # Has the db already gone down, before the ros node?
+        self._gone_down = False
+
+        self._ready = False # is the db ready: when mongo says "waiting for connection"
+        
+        # Start the mongodb server
+        self._mongo_loop()
+
+        
+        
+    def _mongo_loop(self):
+
+        # Blocker to prevent Ctrl-C being passed to the mongo server
+        def block_mongo_kill():
+            os.setpgrp()
+#            signal.signal(signal.SIGINT, signal.SIG_IGN)
+        
+        self._mongo_process = subprocess.Popen(["mongod","--dbpath",self._db_path,"--port",str(self._mongo_port)],
+                                         stdout=subprocess.PIPE,
+                                         preexec_fn = block_mongo_kill)
+
+        while self._mongo_process.poll() is None:# and not rospy.is_shutdown():
+            try:
+                stdout = self._mongo_process.stdout.readline()
+            except IOError, e: # probably interupt because shutdown cut it up
+                if e.errno == errno.EINTR:
+                    continue
+                else:
+                    raise
+            if stdout is not None:
+                if stdout.find("ERROR") !=-1:
+                    rospy.logerr(stdout.strip())
+                else:
+                    rospy.loginfo(stdout.strip())
+
+                if stdout.find("waiting for connections on port"):
+                    self._ready=True
+
+        if not rospy.is_shutdown():
+            rospy.logerr("MongoDB process stopped!")
+            
+        if self._mongo_process.returncode!=0:
+            rospy.logerr("Mongo process error! Exit code="+str(self._mongo_process.returncode))
+
+        self._gone_down = True
+        self._ready=False
+
+    def _on_node_shutdown(self):
+        rospy.loginfo("Shutting down datacentre")
+        if self._gone_down:
+            rospy.logwarn("It looks like Mongo already died. Watch out as the DB might need recovery time at next run.")
+            return
+        try:
+            c = pymongo.MongoClient(self._mongo_host,self._mongo_port)
+        except ConnectionError, c:
+            pass
+        try:
+            c.admin.command("shutdown")
+        except pymongo.errors.AutoReconnect, a:
+            pass
+
+
+    def _shutdown_srv_cb(self,req):
+        rospy.signal_shutdown("Shutdown request..")
+        return EmptyResponse()
+
+    def _wait_ready_srv_cb(self,req):
+        while not self._ready:
+            rospy.sleep(0.1)
+        return EmptyResponse()
+            
+
+if __name__ == '__main__':
+    server = MongoServer()
+

--- a/strands_datacentre/srv/GetParam.srv
+++ b/strands_datacentre/srv/GetParam.srv
@@ -1,0 +1,4 @@
+string param_name
+---
+bool success
+string param_value

--- a/strands_datacentre/srv/SetParam.srv
+++ b/strands_datacentre/srv/SetParam.srv
@@ -1,0 +1,3 @@
+string param
+---
+bool success


### PR DESCRIPTION
This new  package contains a single node that starts a MongoDB server, which can be used to store anything. I imagine using it to store both configuration data (eg. maps with meta-data ( patrolling waypoints), charging station parameters, diagnostics "on-call" contacts) and general long-term experiences (ros messages, particularly QSR rerpresentations of perception).

This package requires MongoDB and python-pmongo:

```
sudo apt-get install mongodb
sudo apt-get install python-pymongo
```

C++ and Python mongo wrappers are available, so I imagine client programs will often communicate directly with MongoDB directly rather than through ros service calls. However, for system parameters I suggest we create another node that loads parameters from the mongodb onto the ros parameter server, overlayed on top of a set of standard parameters allowing each partner to have there own config. 
