### PR TITLE
Saves and reads the total mileage from the datacentre.

### DIFF
--- a/odometry_mileage/CMakeLists.txt
+++ b/odometry_mileage/CMakeLists.txt
@@ -9,6 +9,7 @@ find_package(catkin REQUIRED COMPONENTS
   std_msgs
   nav_msgs
   geometry_msgs
+  strands_datacentre
 )
 
 ## System dependencies are found with CMake's conventions
@@ -108,7 +109,7 @@ add_executable(odometry_mileage src/odometry_mileage.cpp)
 
 ## Add cmake target dependencies of the executable/library
 ## as an example, message headers may need to be generated before nodes
-# add_dependencies(odometry_mileage_node odometry_mileage_generate_messages_cpp)
+add_dependencies(odometry_mileage strands_datacentre_generate_messages_cpp)
 
 ## Specify libraries to link a library or executable target against
 target_link_libraries(odometry_mileage

--- a/odometry_mileage/README.md
+++ b/odometry_mileage/README.md
@@ -4,3 +4,12 @@ This very simple node subscribes to `/odom` and calculates the travelled distanc
 The result is publish on `/odom_mileage`.
 
 Start with `rosrun odomoetry_mileage odometry_mileage`
+
+If the parametere mileage is present on the rosparam server (e.g. via the datacentre), then the node will use the stored mileage to intialise itself.
+While the node is running the mileage parameter is constantly set to the current value and saved to the datacentre. The default save interval
+is every 500 odometry messages, which is every ~10 seconds. This can be change via the `save_interval` parametre.
+
+To initialise your node with the current mileage on the robot do:
+* `rostopic echo -n 1 /mileage` and copy that value
+* `rosparam set mileage <your mileage value>`
+* `rosservice call /config_manager/save_param mileage`

--- a/odometry_mileage/README.md
+++ b/odometry_mileage/README.md
@@ -9,7 +9,7 @@ If the parametere mileage is present on the rosparam server (e.g. via the datace
 While the node is running the mileage parameter is constantly set to the current value and saved to the datacentre. The default save interval
 is every 500 odometry messages, which is every ~10 seconds. This can be change via the `save_interval` parametre.
 
-To initialise your node with the current mileage on the robot do:
+To initialise your node with the current mileage on the robot do: *(Only do this before you launche the node for the first time!)*
 * `rostopic echo -n 1 /mileage` and copy that value
 * `rosparam set mileage <your mileage value>`
 * `rosservice call /config_manager/save_param mileage`

--- a/odometry_mileage/package.xml
+++ b/odometry_mileage/package.xml
@@ -42,10 +42,16 @@
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>std_msgs</build_depend>
+  <build_depend>nav_msgs</build_depend>
+  <build_depend>geometry_msgs</build_depend>
   <build_depend>tf</build_depend>
+  <build_depend>strands_datacentre</build_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>std_msgs</run_depend>
+  <run_depend>nav_msgs</run_depend>
+  <run_depend>geometry_msgs</run_depend>
   <run_depend>tf</run_depend>
+  <run_depend>strands_datacentre</run_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->


### PR DESCRIPTION
This change introduces the functionality of having a mileage parametre and saving it in the datacentre to counter the risk of data loss when crashing.

The node is initialise with the mileage stored in the mileage parametre and saves the current mileage to the datacentre every ~10 seconds (see README for details).

To set your mileage parameter to the current mileage on the robot before starting the node for the first time follow the instructions in the README file.
