### PR TITLE
Node checks against published mileage on start-up

### DIFF
--- a/odometry_mileage/README.md
+++ b/odometry_mileage/README.md
@@ -5,11 +5,8 @@ The result is publish on `/odom_mileage`.
 
 Start with `rosrun odomoetry_mileage odometry_mileage`
 
-If the parametere mileage is present on the rosparam server (e.g. via the datacentre), then the node will use the stored mileage to intialise itself.
+If the parametere `saved_mileage` is present on the rosparam server (e.g. via the datacentre), then the node will use the stored mileage to intialise itself.
+The node will also check against the actual `/mileage` topic on startup and will choose the large of both (parameter or published value). The `mileage` topic might be actually higher then the `odom_mileage` topic after restarting the robot because at that point the mileage is read directly from the EEPROM and the odometry_mileage node might not have been running all the time when the system crashes. 
+
 While the node is running the mileage parameter is constantly set to the current value and saved to the datacentre. The default save interval
 is every 500 odometry messages, which is every ~10 seconds. This can be change via the `save_interval` parametre.
-
-To initialise your node with the current mileage on the robot do: *(Only do this before you launche the node for the first time!)*
-* `rostopic echo -n 1 /mileage` and copy that value
-* `rosparam set saved_mileage <your mileage value>`
-* `rosservice call /config_manager/save_param saved_mileage`


### PR DESCRIPTION
The /mileage topic is checked once on start-up and the larger of the two values (parametre saved_mileage or published mileage) is chosen to initialise the node.
