### PR TITLE
Add option to extract primitives in cross-section

### DIFF
--- a/primitive_extraction/launch/extraction.launch
+++ b/primitive_extraction/launch/extraction.launch
@@ -9,9 +9,15 @@
     <arg name="extract_planes" default="true"/>
     <arg name="extract_cylinders" default="true"/>
     <arg name="extract_spheres" default="true"/>
+    <!-- The min and max height between which to extract, 0 for no bounds -->
+    <arg name="min_height" default="0.0"/>
+    <arg name="max_height" default="0.0"/>
 
     <!-- Launch the primitive extraction -->
 	<node pkg="primitive_extraction" type="extraction" name="extraction" output="screen">
+	    <!-- The min and max height between which to extract, 0 for no bounds -->
+	    <param name="min_height" type="double" value="$(arg min_height)"/>
+	    <param name="max_height" type="double" value="$(arg max_height)"/>
 	    <param name="subsampling_voxel_size" type="double" value="0.015"/>
 	    <param name="number_disjoint_subsets" type="int" value="10"/>
 	    <!-- The size of the octree nodes, mainly influences speed -->

--- a/primitive_extraction/launch/extraction.launch
+++ b/primitive_extraction/launch/extraction.launch
@@ -18,14 +18,14 @@
 	    <!-- The min and max height between which to extract, 0 for no bounds -->
 	    <param name="min_height" type="double" value="$(arg min_height)"/>
 	    <param name="max_height" type="double" value="$(arg max_height)"/>
-	    <param name="subsampling_voxel_size" type="double" value="0.015"/>
+	    <param name="subsampling_voxel_size" type="double" value="0.01"/>
 	    <param name="number_disjoint_subsets" type="int" value="10"/>
 	    <!-- The size of the octree nodes, mainly influences speed -->
 	    <param name="octree_leaf_size" type="double" value="1.0"/>
 	    <!-- The size of the neighbourhood used to compute normals -->
 	    <param name="normal_neigbourhood" type="double" value="0.03"/>
 	    <!-- Largest distance from primitive for a point to be inlier -->
-	    <param name="inlier_threshold" type="double" value="0.04"/>
+	    <param name="inlier_threshold" type="double" value="0.03"/>
 	    <!-- The largest allowed deviation of point normal from surface normal -->
 	    <param name="angle_threshold" type="double" value="0.3"/>
 	    <!-- The probability of extracting a primitive which is not the largest -->
@@ -36,7 +36,7 @@
 	    <param name="min_terminate" type="int" value="3000"/>
 	    <!-- Discretization of connectedness on primitive surfaces -->
 	    <!-- Used to extract the largest connected region -->
-	    <param name="connectedness_dist" type="double" value="0.05"/>
+	    <param name="connectedness_dist" type="double" value="0.04"/>
 	    <!-- Do not consider any points further away from the camera than this -->
 	    <param name="distance_threshold" type="double" value="0.0"/>
 	    <!-- Choose which types of primitives to extract -->

--- a/primitive_extraction/src/extraction.cpp
+++ b/primitive_extraction/src/extraction.cpp
@@ -20,6 +20,8 @@ ros::Publisher pub;
 double subsampling_voxel_size;
 primitive_params params;
 std::vector<base_primitive*> primitives;
+double min_height;
+double max_height;
 
 void write_plane_msg(primitive_extraction::Primitive& msg, const Eigen::VectorXd& data, std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> >& points)
 {
@@ -98,6 +100,10 @@ void callback(const sensor_msgs::PointCloud2::ConstPtr& msg)
     pcl::VoxelGrid<pcl::PointXYZ> sor;
     sor.setInputCloud(msg_cloud);
     sor.setLeafSize(subsampling_voxel_size, subsampling_voxel_size, subsampling_voxel_size);
+    if (min_height != 0.0 || max_height != 0.0) {
+        sor.setFilterFieldName("z");
+        sor.setFilterLimits(min_height, max_height);
+    }
     sor.filter(*cloud);
     ROS_INFO("Downsampled to %lu", cloud->size());
 
@@ -161,6 +167,8 @@ int main(int argc, char** argv)
     pn.param<bool>("extract_planes", extract_planes, true);
     pn.param<bool>("extract_cylinders", extract_cylinders, true);
     pn.param<bool>("extract_spheres", extract_spheres, true);
+    pn.param<double>("min_height", min_height, 0.0);
+    pn.param<double>("max_height", max_height, 0.0);
     std::string input;
     pn.param<std::string>("input", input, std::string("/primitive_extraction/input"));
     std::string output;


### PR DESCRIPTION
This enables us to just look for primitives at a certain height, making table detection a lot faster.
