### PR TITLE
Adding sound_play to the run dependencies of fake_camera_effects.

### DIFF
--- a/fake_camera_effects/package.xml
+++ b/fake_camera_effects/package.xml
@@ -50,6 +50,7 @@
   <run_depend>actionlib_msgs</run_depend>
   <run_depend>message_runtime</run_depend>
   <run_depend>rospy</run_depend>
+  <run_depend>sound_play</run_depend>
   <run_depend>std_msgs</run_depend>
 
 


### PR DESCRIPTION
This is a standard hydro package that is used to play the 'click' sound of the camera. Running rosdep as described in the install instructions: `rosdep install --from-paths src --ignore-src --rosdistro hydro -y -r` will install it.
See https://github.com/strands-project/strands_deployment/issues/38
