### PR TITLE
Fixing wrong message names

### DIFF
--- a/qr_read_and_tweet/package.xml
+++ b/qr_read_and_tweet/package.xml
@@ -34,6 +34,10 @@
   <build_depend>image_transport</build_depend>
   <build_depend>opencv2</build_depend>
   <build_depend>libdmtx-dev</build_depend>
+  <build_depend>mongodb_store</build_depend>
+  <build_depend>strands_tweets</build_depend>
+  <build_depend>fake_camera_effects</build_depend>
+  <build_depend>strands_webserver</build_depend>
 
   <run_depend>cv_bridge</run_depend>
   <run_depend>roscpp</run_depend>
@@ -45,6 +49,10 @@
   <run_depend>image_transport</run_depend>
   <run_depend>opencv2</run_depend>
   <run_depend>libdmtx-dev</run_depend>
+  <run_depend>mongodb_store</run_depend>
+  <run_depend>strands_tweets</run_depend>
+  <run_depend>fake_camera_effects</run_depend>
+  <run_depend>strands_webserver</run_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->


### PR DESCRIPTION
See: https://github.com/strands-project/strands_deployment/issues/42
- Messages have been renamed to match current file structure.
- ros_datacentre was renamed to mongodb_store.
